### PR TITLE
Bevy 0.13.1compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ categories = ["gui", "game-development"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.12.0"
-bevy_mod_picking = "0.17.0"
+bevy = "0.13.1"
+bevy_mod_picking = "0.18.2"
 impl-trait-for-tuples = "0.2.2"
 static_init = "1.0.3"
 winnow = "0.5.19"

--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bevy", "color"]
 # workspace = true
 
 [dependencies]
-bevy = "0.12.0"
-bevy_reflect = "0.12.0"
-bevy_render = "0.12.0"
+bevy = "0.13.1"
+bevy_reflect = "0.13.1"
+bevy_render = "0.13.1"
 serde = "1.0.193"

--- a/crates/bevy_egret/Cargo.toml
+++ b/crates/bevy_egret/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = "0.12.0"
-bevy_mod_picking = "0.17.0"
+bevy = "0.13.1"
+bevy_mod_picking = "0.18.2"
 bevy_quill = { path = "../.." }
 bevy_tabindex = { path = "../bevy_tabindex" }
 static_init = "1.0.3"

--- a/crates/bevy_egret/src/events.rs
+++ b/crates/bevy_egret/src/events.rs
@@ -21,6 +21,7 @@ impl Plugin for EgretEventsPlugin {
 
 /// Event that is triggered when a button is clicked
 #[derive(Clone, Event, EntityEvent)]
+#[can_bubble]
 pub struct Clicked {
     #[target]
     pub target: Entity,
@@ -29,6 +30,7 @@ pub struct Clicked {
 
 /// Event emitted by a widget that contains a value; indicates that the value has changed.
 #[derive(Clone, Event, EntityEvent)]
+#[can_bubble]
 pub struct ValueChanged<T: Clone + Send + Sync + 'static> {
     #[target]
     pub target: Entity,
@@ -65,6 +67,7 @@ pub enum MenuAction {
 
 /// Sent by MenuButton to toggle menu open/closed.
 #[derive(Clone, Event, EntityEvent)]
+#[can_bubble]
 pub struct MenuEvent {
     #[target]
     pub target: Entity,
@@ -72,6 +75,7 @@ pub struct MenuEvent {
 }
 
 #[derive(Clone, Event, EntityEvent)]
+#[can_bubble]
 pub struct SplitterEvent {
     #[target]
     pub target: Entity,

--- a/crates/bevy_grackle/Cargo.toml
+++ b/crates/bevy_grackle/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = "0.12.0"
-bevy_mod_picking = "0.17.0"
+bevy = "0.13.1"
+bevy_mod_picking = "0.18.2"
 bevy_quill = { path = "../.." }
 bevy_egret = { path = "../bevy_egret" }
 static_init = "1.0.3"

--- a/crates/bevy_tabindex/Cargo.toml
+++ b/crates/bevy_tabindex/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["bevy", "accessibility"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.12.0"
+bevy = "0.13.1"

--- a/examples/complex/dialog.rs
+++ b/examples/complex/dialog.rs
@@ -94,6 +94,7 @@ pub struct DemoDialogProps {
 }
 
 #[derive(Clone, Event, EntityEvent)]
+#[can_bubble]
 pub struct RequestClose {
     #[target]
     pub target: Entity,

--- a/examples/complex/disclosure.rs
+++ b/examples/complex/disclosure.rs
@@ -45,6 +45,7 @@ pub struct DisclosureTriangleProps {
 }
 
 #[derive(Clone, Event, EntityEvent)]
+#[can_bubble]
 pub struct ToggleExpand {
     #[target]
     pub target: Entity,

--- a/examples/complex/main.rs
+++ b/examples/complex/main.rs
@@ -216,7 +216,23 @@ impl Default for PanelWidth {
 pub struct ClickLog(Vec<String>);
 
 fn setup_view_root(mut commands: Commands) {
-    commands.spawn((ViewHandle::new(ui_main, ()), Name::new("ViewRoot")));
+    let camera2d = commands
+        .spawn((Camera2dBundle {
+            camera: Camera {
+                // HUD goes on top of 3D
+                order: 1,
+                clear_color: ClearColorConfig::None,
+                ..default()
+            },
+            ..default()
+        },))
+        .id();
+
+    commands.spawn((
+        ViewHandle::new(ui_main, ()),
+        Name::new("ViewRoot"),
+        TargetCamera(camera2d)
+    ));
 }
 
 fn ui_main(mut cx: Cx) -> impl View {

--- a/examples/complex/main.rs
+++ b/examples/complex/main.rs
@@ -418,7 +418,7 @@ fn color_edit(cx: Cx) -> impl View {
         ))
 }
 
-fn handle_tab(nav: TabNavigation, key: Res<Input<KeyCode>>, mut focus: ResMut<Focus>) {
+fn handle_tab(nav: TabNavigation, key: Res<ButtonInput<KeyCode>>, mut focus: ResMut<Focus>) {
     if key.just_pressed(KeyCode::Tab) {
         let next = nav.navigate(
             focus.0,

--- a/examples/complex/test_scene.rs
+++ b/examples/complex/test_scene.rs
@@ -1,12 +1,7 @@
 use std::f32::consts::PI;
 
 use bevy::{
-    core_pipeline::clear_color::ClearColorConfig,
-    prelude::*,
-    render::{
-        camera::Viewport,
-        render_resource::{Extent3d, TextureDimension, TextureFormat},
-    },
+    prelude::*, render::{camera::{ClearColor, ClearColorConfig, Viewport}, render_asset::RenderAssetUsages, render_resource::{Extent3d, TextureDimension, TextureFormat}}
 };
 
 use crate::viewport::*;
@@ -34,13 +29,13 @@ pub fn setup(
     });
 
     let shapes = [
-        meshes.add(shape::Cube::default().into()),
-        meshes.add(shape::Box::default().into()),
-        meshes.add(shape::Capsule::default().into()),
-        meshes.add(shape::Torus::default().into()),
-        meshes.add(shape::Cylinder::default().into()),
-        meshes.add(shape::Icosphere::default().try_into().unwrap()),
-        meshes.add(shape::UVSphere::default().into()),
+        meshes.add(Cuboid::default().mesh().scaled_by(Vec3::new(1.0, 1.0, 1.0))),
+        meshes.add(Cuboid::default().mesh().scaled_by(Vec3::new(1.0, 2.0, 1.0))),
+        meshes.add(Capsule3d::default().mesh()),
+        meshes.add(Torus::default().mesh()),
+        meshes.add(Cylinder::default().mesh()),
+        meshes.add(Sphere::default().mesh().ico(5).unwrap()),
+        meshes.add(Sphere::default().mesh().uv(32, 18)),
     ];
 
     let num_shapes = shapes.len();
@@ -75,35 +70,32 @@ pub fn setup(
 
     // ground plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(50.0).into()),
-        material: materials.add(Color::SILVER.into()),
+        mesh: meshes.add(Plane3d::default().mesh().size(50.0, 50.0)),
+        material: materials.add(Color::SILVER),
         ..default()
     });
 
-    commands.spawn((
+    let camera2d = commands.spawn((
         Camera2dBundle {
             camera: Camera {
                 // HUD goes on top of 3D
                 order: 1,
-                ..default()
-            },
-            camera_2d: Camera2d {
                 clear_color: ClearColorConfig::None,
+                ..default()
             },
             ..default()
         },
-        UiCameraConfig { show_ui: true },
-    ));
+    )).id();
 
-    commands.spawn((
+    let camera3d = commands.spawn((
         Camera3dBundle {
             transform: Transform::from_xyz(0.0, 6., 12.0)
                 .looking_at(Vec3::new(0., 1., 0.), Vec3::Y),
             ..default()
         },
         PrimaryCamera,
-        UiCameraConfig { show_ui: false },
-    ));
+    )).id();
+
 }
 
 pub(crate) fn update_viewport_inset(
@@ -207,5 +199,6 @@ fn uv_debug_texture() -> Image {
         TextureDimension::D2,
         &texture_data,
         TextureFormat::Rgba8UnormSrgb,
+        RenderAssetUsages::default()
     )
 }

--- a/examples/complex/test_scene.rs
+++ b/examples/complex/test_scene.rs
@@ -59,7 +59,7 @@ pub fn setup(
 
     commands.spawn(PointLightBundle {
         point_light: PointLight {
-            intensity: 9000.0,
+            intensity: 9_000_000.0,
             range: 100.,
             shadows_enabled: true,
             ..default()

--- a/examples/complex/test_scene.rs
+++ b/examples/complex/test_scene.rs
@@ -1,7 +1,7 @@
 use std::f32::consts::PI;
 
 use bevy::{
-    prelude::*, render::{camera::{ClearColor, ClearColorConfig, Viewport}, render_asset::RenderAssetUsages, render_resource::{Extent3d, TextureDimension, TextureFormat}}
+    prelude::*, render::{camera::Viewport, render_asset::RenderAssetUsages, render_resource::{Extent3d, TextureDimension, TextureFormat}}
 };
 
 use crate::viewport::*;
@@ -75,26 +75,14 @@ pub fn setup(
         ..default()
     });
 
-    let camera2d = commands.spawn((
-        Camera2dBundle {
-            camera: Camera {
-                // HUD goes on top of 3D
-                order: 1,
-                clear_color: ClearColorConfig::None,
-                ..default()
-            },
-            ..default()
-        },
-    )).id();
-
-    let camera3d = commands.spawn((
+    commands.spawn((
         Camera3dBundle {
             transform: Transform::from_xyz(0.0, 6., 12.0)
                 .looking_at(Vec3::new(0., 1., 0.), Vec3::Y),
             ..default()
         },
         PrimaryCamera,
-    )).id();
+    ));
 
 }
 

--- a/examples/create_atom.rs
+++ b/examples/create_atom.rs
@@ -66,7 +66,7 @@ fn setup(
 ) {
     commands.spawn(PointLightBundle {
         point_light: PointLight {
-            intensity: 9000.0,
+            intensity: 9_000_000.0,
             range: 100.,
             shadows_enabled: true,
             ..default()

--- a/examples/create_atom.rs
+++ b/examples/create_atom.rs
@@ -77,8 +77,8 @@ fn setup(
 
     // ground plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(50.0).into()),
-        material: materials.add(Color::SILVER.into()),
+        mesh: meshes.add(Plane3d::default().mesh().size(50.0, 50.0)),
+        material: materials.add(Color::SILVER),
         ..default()
     });
 

--- a/examples/inset_view.rs
+++ b/examples/inset_view.rs
@@ -310,7 +310,7 @@ fn setup(
 
     commands.spawn((PointLightBundle {
         point_light: PointLight {
-            intensity: 9000.0,
+            intensity: 9_000_000.0,
             range: 100.,
             shadows_enabled: true,
             ..default()

--- a/examples/iter.rs
+++ b/examples/iter.rs
@@ -41,7 +41,7 @@ pub struct List {
 
 fn update_counter(
     mut counter: ResMut<List>,
-    key: Res<Input<KeyCode>>,
+    key: Res<ButtonInput<KeyCode>>,
     mut random: ResMut<Random32>,
 ) {
     if key.pressed(KeyCode::Space) {
@@ -72,8 +72,8 @@ fn setup(
 
     // ground plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(50.0).into()),
-        material: materials.add(Color::SILVER.into()),
+        mesh: meshes.add(Plane3d::default().mesh().size(50.0, 50.0)),
+        material: materials.add(Color::SILVER),
         ..default()
     });
 

--- a/examples/iter.rs
+++ b/examples/iter.rs
@@ -61,7 +61,7 @@ fn setup(
 ) {
     commands.spawn(PointLightBundle {
         point_light: PointLight {
-            intensity: 9000.0,
+            intensity: 9_000_000.0,
             range: 100.,
             shadows_enabled: true,
             ..default()

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -51,7 +51,7 @@ pub struct Counter {
     pub foo: usize,
 }
 
-fn update_counter(mut counter: ResMut<Counter>, key: Res<Input<KeyCode>>) {
+fn update_counter(mut counter: ResMut<Counter>, key: Res<ButtonInput<KeyCode>>) {
     if key.pressed(KeyCode::Space) {
         counter.count += 1;
     }
@@ -75,8 +75,8 @@ fn setup(
 
     // ground plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(50.0).into()),
-        material: materials.add(Color::SILVER.into()),
+        mesh: meshes.add(Plane3d::default().mesh().size(50.0, 50.0)),
+        material: materials.add(Color::SILVER),
         ..default()
     });
 

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -64,7 +64,7 @@ fn setup(
 ) {
     commands.spawn(PointLightBundle {
         point_light: PointLight {
-            intensity: 9000.0,
+            intensity: 9_000_000.0,
             range: 100.,
             shadows_enabled: true,
             ..default()

--- a/examples/scoped.rs
+++ b/examples/scoped.rs
@@ -79,7 +79,7 @@ pub struct Counter {
     pub foo: usize,
 }
 
-fn update_counter(mut counter: ResMut<Counter>, key: Res<Input<KeyCode>>) {
+fn update_counter(mut counter: ResMut<Counter>, key: Res<ButtonInput<KeyCode>>) {
     if key.pressed(KeyCode::Space) {
         counter.count += 1;
     }
@@ -104,8 +104,8 @@ fn setup(
 
     // ground plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(50.0).into()),
-        material: materials.add(Color::SILVER.into()),
+        mesh: meshes.add(Plane3d::default().mesh().size(50.0, 50.0)),
+        material: materials.add(Color::SILVER),
         ..default()
     });
 

--- a/examples/scoped.rs
+++ b/examples/scoped.rs
@@ -93,7 +93,7 @@ fn setup(
 ) {
     commands.spawn(PointLightBundle {
         point_light: PointLight {
-            intensity: 9000.0,
+            intensity: 9_000_000.0,
             range: 100.,
             shadows_enabled: true,
             ..default()

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -97,7 +97,7 @@ fn setup(
 
     commands.spawn(PointLightBundle {
         point_light: PointLight {
-            intensity: 9000.0,
+            intensity: 9_000_000.0,
             range: 100.,
             shadows_enabled: true,
             ..default()

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -3,7 +3,7 @@
 use std::f32::consts::PI;
 
 use bevy::{
-    math::primitives, prelude::*, render::{mesh::SphereKind, render_asset::RenderAssetUsages, render_resource::{Extent3d, TextureDimension, TextureFormat}}
+    prelude::*, render::{render_asset::RenderAssetUsages, render_resource::{Extent3d, TextureDimension, TextureFormat}}
 };
 use bevy_mod_picking::{
     backends::bevy_ui::BevyUiBackend,

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -3,8 +3,7 @@
 use std::f32::consts::PI;
 
 use bevy::{
-    prelude::*,
-    render::render_resource::{Extent3d, TextureDimension, TextureFormat},
+    math::primitives, prelude::*, render::{mesh::SphereKind, render_asset::RenderAssetUsages, render_resource::{Extent3d, TextureDimension, TextureFormat}}
 };
 use bevy_mod_picking::{
     backends::bevy_ui::BevyUiBackend,
@@ -49,7 +48,7 @@ pub struct Counter {
     pub foo: usize,
 }
 
-fn update_counter(mut counter: ResMut<Counter>, key: Res<Input<KeyCode>>) {
+fn update_counter(mut counter: ResMut<Counter>, key: Res<ButtonInput<KeyCode>>) {
     if key.pressed(KeyCode::Space) {
         counter.count += 1;
     }
@@ -68,13 +67,13 @@ fn setup(
     });
 
     let shapes = [
-        meshes.add(shape::Cube::default().into()),
-        meshes.add(shape::Box::default().into()),
-        meshes.add(shape::Capsule::default().into()),
-        meshes.add(shape::Torus::default().into()),
-        meshes.add(shape::Cylinder::default().into()),
-        meshes.add(shape::Icosphere::default().try_into().unwrap()),
-        meshes.add(shape::UVSphere::default().into()),
+        meshes.add(Cuboid::default().mesh().scaled_by(Vec3::new(1.0, 1.0, 1.0))),
+        meshes.add(Cuboid::default().mesh().scaled_by(Vec3::new(1.0, 2.0, 1.0))),
+        meshes.add(Capsule3d::default().mesh()),
+        meshes.add(Torus::default().mesh()),
+        meshes.add(Cylinder::default().mesh()),
+        meshes.add(Sphere::default().mesh().ico(5).unwrap()),
+        meshes.add(Sphere::default().mesh().uv(32, 18)),
     ];
 
     let num_shapes = shapes.len();
@@ -109,8 +108,8 @@ fn setup(
 
     // ground plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(50.0).into()),
-        material: materials.add(Color::SILVER.into()),
+        mesh: meshes.add(Plane3d::default().mesh().size(50.0, 50.0)),
+        material: materials.add(Color::SILVER),
         ..default()
     });
 
@@ -151,5 +150,6 @@ fn uv_debug_texture() -> Image {
         TextureDimension::D2,
         &texture_data,
         TextureFormat::Rgba8UnormSrgb,
+        RenderAssetUsages::default()
     )
 }

--- a/examples/styling.rs
+++ b/examples/styling.rs
@@ -102,7 +102,7 @@ pub struct Counter {
     pub foo: usize,
 }
 
-fn update_counter(mut counter: ResMut<Counter>, key: Res<Input<KeyCode>>) {
+fn update_counter(mut counter: ResMut<Counter>, key: Res<ButtonInput<KeyCode>>) {
     if key.pressed(KeyCode::Space) {
         counter.count += 1;
     }
@@ -127,8 +127,8 @@ fn setup(
 
     // ground plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(50.0).into()),
-        material: materials.add(Color::SILVER.into()),
+        mesh: meshes.add(Plane3d::default().mesh().size(50.0, 50.0)),
+        material: materials.add(Color::SILVER),
         ..default()
     });
 

--- a/examples/styling.rs
+++ b/examples/styling.rs
@@ -116,7 +116,7 @@ fn setup(
 ) {
     commands.spawn(PointLightBundle {
         point_light: PointLight {
-            intensity: 9000.0,
+            intensity: 9_000_000.0,
             range: 100.,
             shadows_enabled: true,
             ..default()

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -8,7 +8,6 @@ use bevy::ecs::system::Command;
 use bevy::prelude::*;
 use bevy::text::BreakLineOn;
 use bevy::ui::widget::UiImageSize;
-use bevy::ui::widget::TextFlags;
 use bevy::ui::ContentSize;
 use bevy::utils::HashMap;
 use bevy_mod_picking::prelude::Pickable;

--- a/src/style/computed.rs
+++ b/src/style/computed.rs
@@ -8,6 +8,7 @@ use bevy::ecs::system::Command;
 use bevy::prelude::*;
 use bevy::text::BreakLineOn;
 use bevy::ui::widget::UiImageSize;
+use bevy::ui::widget::TextFlags;
 use bevy::ui::ContentSize;
 use bevy::utils::HashMap;
 use bevy_mod_picking::prelude::Pickable;
@@ -19,7 +20,7 @@ pub struct ComputedStyle {
     pub style: Style,
 
     // Text properties
-    pub alignment: Option<TextAlignment>,
+    pub alignment: Option<JustifyText>,
     pub color: Option<Color>,
     pub font_size: Option<f32>,
     pub font: Option<AssetPath<'static>>,
@@ -331,7 +332,7 @@ impl Command for UpdateComputedStyle {
         match (self.computed.pickable, e.get_mut::<Pickable>()) {
             (Some(pe), Some(mut pickable)) => {
                 pickable.should_block_lower = pe == PointerEvents::All;
-                pickable.should_emit_events = pe == PointerEvents::All;
+                pickable.is_hoverable = pe == PointerEvents::All;
             }
             (None, Some(_)) => {
                 e.remove::<Pickable>();
@@ -339,7 +340,7 @@ impl Command for UpdateComputedStyle {
             (Some(pe), None) => {
                 e.insert(Pickable {
                     should_block_lower: pe == PointerEvents::All,
-                    should_emit_events: pe == PointerEvents::All,
+                    is_hoverable: pe == PointerEvents::All,
                 });
             }
             (None, None) => {}

--- a/src/view/view_insert_bundle.rs
+++ b/src/view/view_insert_bundle.rs
@@ -21,7 +21,11 @@ impl<V: View, B: Bundle> ViewInsertBundle<V, B> {
             NodeSpan::Empty => (),
             NodeSpan::Node(entity) => {
                 let em = &mut bc.entity_mut(*entity);
-                em.insert(self.bundle.take().unwrap());
+                if let Some(bundle) = self.bundle.take() {
+                    em.insert(bundle);
+                } else {
+                    panic!("No bundle to insert");
+                }
             }
             NodeSpan::Fragment(ref _nodes) => {
                 panic!("Can only insert into a singular node")


### PR DESCRIPTION
Hello! I've upgraded the library to work with bevy 0.13.

I didn't include a version bump in the manifest since I don't know the right version to set for such a change.  (probably a major version bump but that's up to you)

Please let me know if you find anything I missed and I'll update the PR to fix it accordingly.

_P.S: There is a single unrelated test that's failing in bevy_color (oklab to/from srgba), which I'm unsure on how to fix._